### PR TITLE
Fix iOS build failing

### DIFF
--- a/SisouCapacitorBarcodeScanner.podspec
+++ b/SisouCapacitorBarcodeScanner.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'CapacitorCommunityBarcodeScanner'
+  s.name = 'SisouCapacitorBarcodeScanner'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "android/build.gradle",
     "dist/",
     "ios/Plugin/",
-    "CapacitorCommunityBarcodeScanner.podspec"
+    "SisouCapacitorBarcodeScanner.podspec"
   ],
   "author": "tafelnl",
   "license": "MIT",


### PR DESCRIPTION
The pod name need to match the plugin name, if not the build will fail with this error:
```
[!] The name of the given podspec `CommunityCapactiorBarcodeScanner` doesn't match the expected one `SisouCapacitorBarcodeScanner`
```